### PR TITLE
Replace deprecated ::set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         ninja --version
-        echo "::set-output name=version::$(ninja --version)"
+        echo "version=$(ninja --version)" >> $GITHUB_OUTPUT
 branding:
   icon: "archive"
   color: "green"


### PR DESCRIPTION
Replaces the deprecated `::set-output` ([announcement](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)).

Builds issue a warning already, eventually failing next year.